### PR TITLE
Removal of messages

### DIFF
--- a/global.R
+++ b/global.R
@@ -10,7 +10,7 @@ library(shinyjs)
 
 options(shiny.usecairo = TRUE)
 
-data = read_csv("ranking_fifa_historical.csv") %>% 
+data = read_csv("ranking_fifa_historical.csv", show_col_types = FALSE) %>% 
        filter(!is.na(total_points)) %>%
        mutate(team = ifelse(team == "Curaçao", "Curacao", team),
               team = ifelse(team == "Hong Kong, China", "Hong Kong", team)) %>% 

--- a/server.R
+++ b/server.R
@@ -69,7 +69,7 @@ shinyServer(function(input, output, session) {
                          subtitle = paste0("Historical men's FIFA ranking\n\n",
                                            "From ", as.yearmon(input$year[1], "%B%Y"), " to ", as.yearmon(input$year[2], "%B%Y"))) +
                     scale_colour_brewer(palette = "Set1") +
-                    theme(legend.position = c(0.5, 1.05), legend.direction = "horizontal",
+                    theme(legend.position.inside = c(0.5, 1.05), legend.direction = "horizontal",
 
                           axis.text.x = element_text(angle = 90, size = 8),
                           axis.title.x = element_text(size = 14),

--- a/server.R
+++ b/server.R
@@ -76,9 +76,9 @@ shinyServer(function(input, output, session) {
                           axis.title.y = element_text(size = 12),
                           plot.margin = margin(0.5, 0.1, 0.4, 0.2, "cm")) 
                 
-                p <- ggplotly(p, tooltip="label") %>% 
+                p <- suppressWarnings(print(ggplotly(p, tooltip="label") %>% 
                         layout(legend = list(orientation = "h", x = 0, y = 1.1),
-                               margin = list(l = 80, r = 15, b = 80, t = 10))
+                               margin = list(l = 80, r = 15, b = 80, t = 10))))
         })
         
         output$down <- downloadHandler(


### PR DESCRIPTION
After running the Shiny app, these three messages were generated:

1.  Use `spec()` to retrieve the full column specification for this data. ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message.
2. Warning: A numeric `legend.position` argument in `theme()` was deprecated in ggplot2 3.5.0.ℹ Please use the `legend.position.inside` argument of `theme()` instead.
3. Warning: plotly.js does not (yet) support horizontal legend items. You can track progress here: https://github.com/plotly/plotly.js/issues/53

These messages are no longer displayed. Refer to the individual commit messages for details on the specific actions performed.